### PR TITLE
Fix scheduler state_dict to drop the optimizer key by equality

### DIFF
--- a/deepspec/utils/optim.py
+++ b/deepspec/utils/optim.py
@@ -11,7 +11,7 @@ class TwoStageScheduler(_LRScheduler):
 
     def state_dict(self):
         state_dict = {
-            key: value for key, value in self.__dict__.items() if key not in "optimizer"
+            key: value for key, value in self.__dict__.items() if key != "optimizer"
         }
         if isinstance(state_dict["after_scheduler"], _LRScheduler):
             state_dict["after_scheduler_type"] = type(


### PR DESCRIPTION
## What

`TwoStageScheduler.state_dict()` filters out the `optimizer` entry with:

```python
{key: value for key, value in self.__dict__.items() if key not in "optimizer"}
```

`key not in "optimizer"` is a **substring** test against the string `"optimizer"`, not a comparison with the key `"optimizer"`. It only drops the intended `optimizer` reference today because no other scheduler attribute name happens to be a substring of `"optimizer"` (an attribute named e.g. `opt` or `ize` would also be silently dropped), and the intent is unclear to readers.

## Change

Use an equality check, matching `torch.optim.lr_scheduler.LRScheduler.state_dict` and the SpecForge optimizer code this class is adapted from:

```python
{key: value for key, value in self.__dict__.items() if key != "optimizer"}
```

This path runs on every checkpoint save (`BF16Optimizer.state_dict` → `scheduler.state_dict`). No behavior change for the current attribute set — it's a correctness/clarity fix.
