### PR TITLE
Align DSpark/DFlash exp_name with block_size=7 (block7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ bash scripts/eval/eval.sh
 `eval.sh` runs `eval.py` against a trained draft checkpoint over the speculative-decoding benchmarks in [eval_datasets/](./eval_datasets/) (gsm8k, math500, aime25, humaneval, mbpp, livecodebench, mt-bench, alpaca, arena-hard-v2). Set:
 
 - `target_name_or_path` — the target model the draft was trained against (e.g. `Qwen/Qwen3-4B`),
-- `draft_name_or_path` — the draft checkpoint, e.g. `~/checkpoints/deepspec/dspark_block8_qwen3_4b/step_latest`, or one of the Hugging Face repo IDs listed in [Released Checkpoints](#released-checkpoints).
+- `draft_name_or_path` — the draft checkpoint, e.g. `~/checkpoints/deepspec/dspark_block7_qwen3_4b/step_latest`, or one of the Hugging Face repo IDs listed in [Released Checkpoints](#released-checkpoints).
 
 ### Released Checkpoints
 

--- a/config/dflash/dflash_gemma4_12b.py
+++ b/config/dflash/dflash_gemma4_12b.py
@@ -6,7 +6,7 @@ from deepspec.trainer import Gemma4DSparkTrainer
 BASE_TB_DIR = os.path.expanduser("~/tensorboard")
 BASE_CKPT_DIR = os.path.expanduser("~/checkpoints")
 project_name = "deepspec"
-exp_name = "dflash_block8_gemma4_12b"
+exp_name = "dflash_block7_gemma4_12b"
 seed = 42
 
 model = dict(

--- a/config/dflash/dflash_qwen3_14b.py
+++ b/config/dflash/dflash_qwen3_14b.py
@@ -6,7 +6,7 @@ from deepspec.trainer import Qwen3DSparkTrainer
 BASE_TB_DIR = os.path.expanduser("~/tensorboard")
 BASE_CKPT_DIR = os.path.expanduser("~/checkpoints")
 project_name = "deepspec"
-exp_name = "dflash_block8_qwen3_14b"
+exp_name = "dflash_block7_qwen3_14b"
 seed = 42
 
 model = dict(

--- a/config/dflash/dflash_qwen3_4b.py
+++ b/config/dflash/dflash_qwen3_4b.py
@@ -3,7 +3,7 @@ from deepspec.trainer import Qwen3DSparkTrainer
 BASE_TB_DIR = os.path.expanduser("~/tensorboard")
 BASE_CKPT_DIR = os.path.expanduser("~/checkpoints")
 project_name = "deepspec"
-exp_name = "dflash_block8_qwen3_4b"
+exp_name = "dflash_block7_qwen3_4b"
 seed = 42
 
 model = dict(

--- a/config/dflash/dflash_qwen3_8b.py
+++ b/config/dflash/dflash_qwen3_8b.py
@@ -3,7 +3,7 @@ from deepspec.trainer import Qwen3DSparkTrainer
 BASE_TB_DIR = os.path.expanduser("~/tensorboard")
 BASE_CKPT_DIR = os.path.expanduser("~/checkpoints")
 project_name = "deepspec"
-exp_name = "dflash_block8_qwen3_8b"
+exp_name = "dflash_block7_qwen3_8b"
 seed = 42
 
 model = dict(

--- a/config/dspark/dspark_gemma4_12b.py
+++ b/config/dspark/dspark_gemma4_12b.py
@@ -6,7 +6,7 @@ from deepspec.trainer import Gemma4DSparkTrainer
 BASE_TB_DIR = os.path.expanduser("~/tensorboard")
 BASE_CKPT_DIR = os.path.expanduser("~/checkpoints")
 project_name = "deepspec"
-exp_name = "dspark_block8_gemma4_12b"
+exp_name = "dspark_block7_gemma4_12b"
 seed = 42
 
 model = dict(

--- a/config/dspark/dspark_qwen3_14b.py
+++ b/config/dspark/dspark_qwen3_14b.py
@@ -6,7 +6,7 @@ from deepspec.trainer import Qwen3DSparkTrainer
 BASE_TB_DIR = os.path.expanduser("~/tensorboard")
 BASE_CKPT_DIR = os.path.expanduser("~/checkpoints")
 project_name = "deepspec"
-exp_name = "dspark_block8_qwen3_14b"
+exp_name = "dspark_block7_qwen3_14b"
 seed = 42
 
 model = dict(

--- a/config/dspark/dspark_qwen3_4b.py
+++ b/config/dspark/dspark_qwen3_4b.py
@@ -3,7 +3,7 @@ from deepspec.trainer import Qwen3DSparkTrainer
 BASE_TB_DIR = os.path.expanduser("~/tensorboard")
 BASE_CKPT_DIR = os.path.expanduser("~/checkpoints")
 project_name = "deepspec"
-exp_name = "dspark_block8_qwen3_4b"
+exp_name = "dspark_block7_qwen3_4b"
 seed = 42
 
 model = dict(

--- a/config/dspark/dspark_qwen3_8b.py
+++ b/config/dspark/dspark_qwen3_8b.py
@@ -3,7 +3,7 @@ from deepspec.trainer import Qwen3DSparkTrainer
 BASE_TB_DIR = os.path.expanduser("~/tensorboard")
 BASE_CKPT_DIR = os.path.expanduser("~/checkpoints")
 project_name = "deepspec"
-exp_name = "dspark_block8_qwen3_8b"
+exp_name = "dspark_block7_qwen3_8b"
 seed = 42
 
 model = dict(

--- a/scripts/eval/eval.sh
+++ b/scripts/eval/eval.sh
@@ -13,7 +13,7 @@ target_name_or_path=Qwen/Qwen3-4B
 
 # Training writes checkpoints under ~/checkpoints/<project_name>/<exp_name>/step_*.
 # Use step_latest for the most recent checkpoint, or replace it with step_<N>.
-draft_name_or_path=${HOME}/checkpoints/deepspec/dspark_block8_qwen3_4b/step_latest
+draft_name_or_path=${HOME}/checkpoints/deepspec/dspark_block7_qwen3_4b/step_latest
 python eval.py \
     --target_name_or_path ${target_name_or_path} \
     --draft_name_or_path ${draft_name_or_path}


### PR DESCRIPTION
The DSpark and DFlash configs set `block_size=7`, but their `exp_name` values are `*_block8_*`. This is inconsistent with:

- the parameter itself (`block_size=7`),
- the Eagle3 configs, which name experiments after the parameter value (`*_ttt7_*` with `ttt_length=7`), and
- the released checkpoints in the README, which are published as `*_block7_*` / `*_ttt7`.

This renames the DSpark/DFlash experiments to `*_block7_*` so the default checkpoint directory (`~/checkpoints/<project_name>/<exp_name>`) matches both `block_size=7` and the published checkpoint names, and updates the `eval.sh` and README examples that reference that path.

If the `block8` label is intentional, feel free to close — flagging the inconsistency either way.
