### PR TITLE
Remove unused extract_context_feature import from DSpark modeling

### DIFF
--- a/deepspec/modeling/dspark/gemma4/modeling.py
+++ b/deepspec/modeling/dspark/gemma4/modeling.py
@@ -24,7 +24,6 @@ from deepspec.modeling.dspark.common import (
     create_dspark_attention_mask,
     create_noise_embed,
     create_position_ids,
-    extract_context_feature,
     log_sampler_stats,
     sample_anchor_positions,
 )

--- a/deepspec/modeling/dspark/qwen3/modeling.py
+++ b/deepspec/modeling/dspark/qwen3/modeling.py
@@ -24,7 +24,6 @@ from deepspec.modeling.dspark.common import (
     create_dspark_attention_mask,
     create_noise_embed,
     create_position_ids,
-    extract_context_feature,
     log_sampler_stats,
     sample_anchor_positions,
 )


### PR DESCRIPTION
`deepspec/modeling/dspark/qwen3/modeling.py` and `deepspec/modeling/dspark/gemma4/modeling.py` both import `extract_context_feature` from `..common`, but neither file uses it — it is referenced only in `deepspec/eval/dspark/evaluator.py`. Remove the unused import from both modules (flake8 F401).
