### PR TITLE
Fix grammar in the _launch_eval placeholder message

### DIFF
--- a/deepspec/trainer/base_trainer.py
+++ b/deepspec/trainer/base_trainer.py
@@ -143,7 +143,7 @@ def _launch_eval(
     tensorboard_dir: str,
     exp_name: str,
 ) -> None:
-    print("You can use this function to launch to your auto eval script!")
+    print("You can use this function to launch your auto eval script!")
 
 class BaseTrainer:
     data_collator_cls = None


### PR DESCRIPTION
The placeholder message in `_launch_eval` reads "You can use this function to launch to your auto eval script!" — drop the stray "to" so it reads "...launch your auto eval script!".
