### PR TITLE
Fix DataLoader crash when data.num_workers=0

### DIFF
--- a/deepspec/trainer/base_trainer.py
+++ b/deepspec/trainer/base_trainer.py
@@ -294,17 +294,21 @@ class BaseTrainer:
             start_global_offset_samples=start_offset_samples,
             num_samples=num_samples,
         )
-        return DataLoader(
-            self.train_dataset,
+        num_workers = int(self.args.data.num_workers)
+        dataloader_kwargs = dict(
             batch_size=int(self.args.train.local_batch_size),
             sampler=sampler,
             collate_fn=self.data_collator_cls(),
-            num_workers=int(self.args.data.num_workers),
+            num_workers=num_workers,
             pin_memory=True,
             drop_last=True,
-            persistent_workers=True,
-            prefetch_factor=4,
         )
+        # prefetch_factor / persistent_workers are only valid with worker
+        # processes; passing them when num_workers=0 raises a ValueError.
+        if num_workers > 0:
+            dataloader_kwargs["persistent_workers"] = True
+            dataloader_kwargs["prefetch_factor"] = 4
+        return DataLoader(self.train_dataset, **dataloader_kwargs)
 
     def run_batch(self, batch):
         raise NotImplementedError


### PR DESCRIPTION
`_build_train_dataloader` always passes `persistent_workers=True` and `prefetch_factor=4` to `DataLoader`. PyTorch's `DataLoader` rejects both of these when `num_workers=0`:

> ValueError: prefetch_factor option could only be specified in multiprocessing. let num_workers > 0 to enable multiprocessing, otherwise set prefetch_factor to None.

So any run with `data.num_workers=0` crashes at dataloader construction, before training starts. `num_workers=0` is a legitimate setting — single-GPU or debugging runs, or environments where spawning worker processes is undesirable.

This passes `persistent_workers` / `prefetch_factor` only when `num_workers > 0`. Behavior is unchanged for the default `num_workers=4`.
