### PR TITLE
Make step_latest symlink update atomic

### DIFF
--- a/deepspec/utils/io.py
+++ b/deepspec/utils/io.py
@@ -7,7 +7,10 @@ def ensure_dir(path):
 
 
 def safe_symlink(src, dst):
+    # os.replace is atomic, so dst never disappears mid-update.
     dst_path = Path(dst)
-    if dst_path.is_symlink() or dst_path.exists():
-        dst_path.unlink()
-    dst_path.symlink_to(Path(src).resolve())
+    tmp_path = dst_path.with_name(dst_path.name + ".tmp")
+    if tmp_path.is_symlink() or tmp_path.exists():
+        tmp_path.unlink()
+    tmp_path.symlink_to(Path(src).resolve())
+    os.replace(tmp_path, dst_path)


### PR DESCRIPTION
## What

`safe_symlink` unlinks the old symlink before creating the new one. A crash between the two calls deletes `step_latest` entirely, so `discover_latest_checkpoint()` returns None and the next launch silently retrains from scratch — even though a complete checkpoint is sitting on disk.

## Change

Create the symlink under a temporary name and `os.replace` it over the target. The replace is atomic, so `step_latest` always points at a complete checkpoint.