### PR TITLE
Avoid duplicate final checkpoint save

### DIFF
--- a/deepspec/trainer/base_trainer.py
+++ b/deepspec/trainer/base_trainer.py
@@ -358,6 +358,7 @@ class BaseTrainer:
             return
 
         local_batch_size = int(self.args.train.local_batch_size)
+        checkpointing_steps = int(self.args.logging.checkpointing_steps)
         total_micro_steps = self.max_train_steps * self.gradient_accumulation_steps
         remaining_micro_steps = total_micro_steps - self.next_micro_step
         remaining_samples = remaining_micro_steps * local_batch_size
@@ -397,14 +398,15 @@ class BaseTrainer:
                     grad_norm=grad_norm.item(),
                 )
 
-                if self.global_step % int(self.args.logging.checkpointing_steps) == 0:
+                if self.global_step % checkpointing_steps == 0:
                     self.save_and_eval_checkpoint()
 
                 if self.suspend_controller.requested():
                     self._save_and_suspend()
                     return
 
-        self.save_and_eval_checkpoint()
+        if self.global_step % checkpointing_steps != 0:
+            self.save_and_eval_checkpoint()
 
     def clean_up(self):
         training_logger.close()


### PR DESCRIPTION
## What

`BaseTrainer.train()` saves a checkpoint at every configured checkpoint interval, then unconditionally saves again after the training loop.

When the final training step falls on a checkpoint interval, this writes the same `step_<N>` checkpoint twice and submits automatic evaluation twice.

## Change

Only perform the post-loop save when the final step was not already checkpointed.

Runs that finish between checkpoint intervals still save their final checkpoint as before.